### PR TITLE
2/4 업데이트

### DIFF
--- a/lib/constants/gaps.dart
+++ b/lib/constants/gaps.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+
+class Gaps {
+  // Vertical Gaps
+  static const v1 = SizedBox(height: Sizes.size1);
+  static const v2 = SizedBox(height: Sizes.size2);
+  static const v3 = SizedBox(height: Sizes.size3);
+  static const v4 = SizedBox(height: Sizes.size4);
+  static const v5 = SizedBox(height: Sizes.size5);
+  static const v6 = SizedBox(height: Sizes.size6);
+  static const v7 = SizedBox(height: Sizes.size7);
+  static const v8 = SizedBox(height: Sizes.size8);
+  static const v9 = SizedBox(height: Sizes.size9);
+  static const v10 = SizedBox(height: Sizes.size10);
+  static const v11 = SizedBox(height: Sizes.size11);
+  static const v12 = SizedBox(height: Sizes.size12);
+  static const v14 = SizedBox(height: Sizes.size14);
+  static const v16 = SizedBox(height: Sizes.size16);
+  static const v20 = SizedBox(height: Sizes.size20);
+  static const v24 = SizedBox(height: Sizes.size24);
+  static const v28 = SizedBox(height: Sizes.size28);
+  static const v32 = SizedBox(height: Sizes.size32);
+  static const v36 = SizedBox(height: Sizes.size36);
+  static const v40 = SizedBox(height: Sizes.size40);
+  static const v44 = SizedBox(height: Sizes.size44);
+  static const v48 = SizedBox(height: Sizes.size48);
+  static const v52 = SizedBox(height: Sizes.size52);
+  static const v56 = SizedBox(height: Sizes.size56);
+  static const v60 = SizedBox(height: Sizes.size60);
+  static const v64 = SizedBox(height: Sizes.size64);
+  static const v72 = SizedBox(height: Sizes.size72);
+  static const v80 = SizedBox(height: Sizes.size80);
+  static const v96 = SizedBox(height: Sizes.size96);
+
+  // Horizontal Gaps
+  static const h1 = SizedBox(width: Sizes.size1);
+  static const h2 = SizedBox(width: Sizes.size2);
+  static const h3 = SizedBox(width: Sizes.size3);
+  static const h4 = SizedBox(width: Sizes.size4);
+  static const h5 = SizedBox(width: Sizes.size5);
+  static const h6 = SizedBox(width: Sizes.size6);
+  static const h7 = SizedBox(width: Sizes.size7);
+  static const h8 = SizedBox(width: Sizes.size8);
+  static const h9 = SizedBox(width: Sizes.size9);
+  static const h10 = SizedBox(width: Sizes.size10);
+  static const h11 = SizedBox(width: Sizes.size11);
+  static const h12 = SizedBox(width: Sizes.size12);
+  static const h14 = SizedBox(width: Sizes.size14);
+  static const h16 = SizedBox(width: Sizes.size16);
+  static const h20 = SizedBox(width: Sizes.size20);
+  static const h24 = SizedBox(width: Sizes.size24);
+  static const h28 = SizedBox(width: Sizes.size28);
+  static const h32 = SizedBox(width: Sizes.size32);
+  static const h36 = SizedBox(width: Sizes.size36);
+  static const h40 = SizedBox(width: Sizes.size40);
+  static const h44 = SizedBox(width: Sizes.size44);
+  static const h48 = SizedBox(width: Sizes.size48);
+  static const h52 = SizedBox(width: Sizes.size52);
+  static const h56 = SizedBox(width: Sizes.size56);
+  static const h60 = SizedBox(width: Sizes.size60);
+  static const h64 = SizedBox(width: Sizes.size64);
+  static const h72 = SizedBox(width: Sizes.size72);
+  static const h80 = SizedBox(width: Sizes.size80);
+  static const h96 = SizedBox(width: Sizes.size96);
+}

--- a/lib/constants/sizes.dart
+++ b/lib/constants/sizes.dart
@@ -1,0 +1,31 @@
+class Sizes {
+  static const size1 = 1.0;
+  static const size2 = 2.0;
+  static const size3 = 3.0;
+  static const size4 = 4.0;
+  static const size5 = 5.0;
+  static const size6 = 6.0;
+  static const size7 = 7.0;
+  static const size8 = 8.0;
+  static const size9 = 9.0;
+  static const size10 = 10.0;
+  static const size11 = 11.0;
+  static const size12 = 12.0;
+  static const size14 = 14.0;
+  static const size16 = 16.0;
+  static const size20 = 20.0;
+  static const size24 = 24.0;
+  static const size28 = 28.0;
+  static const size32 = 32.0;
+  static const size36 = 36.0;
+  static const size40 = 40.0;
+  static const size44 = 44.0;
+  static const size48 = 48.0;
+  static const size52 = 52.0;
+  static const size56 = 56.0;
+  static const size60 = 60.0;
+  static const size64 = 64.0;
+  static const size72 = 72.0;
+  static const size80 = 80.0;
+  static const size96 = 96.0;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:honbap_signal_flutter/Themes/create_material_color.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
 import 'package:honbap_signal_flutter/routes/route_navigation_widget.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
@@ -25,6 +26,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: '혼밥시그널',
       theme: ThemeData(
+        scaffoldBackgroundColor: Colors.white,
         primarySwatch: createMaterialColor(const Color(0xffff4b25)),
         textTheme: const TextTheme(
           // 2022 sets
@@ -35,12 +37,12 @@ class MyApp extends StatelessWidget {
           // labelLarge, labelMedium, labelSmall
           titleMedium: TextStyle(
             fontWeight: FontWeight.w700,
-            fontSize: 20,
+            fontSize: Sizes.size20,
           ),
           labelSmall: TextStyle(
             color: Color(0xFFB8B8B8),
-            fontSize: 10,
-            letterSpacing: 0.5,
+            fontSize: Sizes.size10,
+            letterSpacing: Sizes.size1 / Sizes.size2,
           ),
         ),
       ),

--- a/lib/routes/route_navigation_widget.dart
+++ b/lib/routes/route_navigation_widget.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
 import 'package:honbap_signal_flutter/screens/chats/chat_list_screen.dart';
+import 'package:honbap_signal_flutter/screens/signal/signal_list_screen.dart';
 
 class RouteNavigationWidget extends StatefulWidget {
   const RouteNavigationWidget({super.key});
@@ -9,7 +11,6 @@ class RouteNavigationWidget extends StatefulWidget {
 }
 
 class _RouteNavigationWidgetState extends State<RouteNavigationWidget> {
-  int _currentIdx = 0;
   List<Widget> screens = [
     const Center(
       child: Text('home'),
@@ -17,9 +18,7 @@ class _RouteNavigationWidgetState extends State<RouteNavigationWidget> {
     const Center(
       child: Text('info'),
     ),
-    const Center(
-      child: Text('location'),
-    ),
+    const SignalListScreen(),
     const Center(
       child: Text('signal'),
     ),
@@ -37,12 +36,12 @@ class _RouteNavigationWidgetState extends State<RouteNavigationWidget> {
             height: double.infinity,
           ),
           Scaffold(
-            body: TabBarView(children: screens),
+            body: TabBarView(
+              physics: const NeverScrollableScrollPhysics(),
+              children: screens,
+            ),
             bottomNavigationBar: SafeArea(
               child: TabBar(
-                onTap: (value) => setState(() {
-                  _currentIdx = value;
-                }),
                 tabs: const [
                   Tab(
                     icon: Icon(
@@ -79,9 +78,10 @@ class _RouteNavigationWidgetState extends State<RouteNavigationWidget> {
                 indicator: UnderlineTabIndicator(
                   borderSide: BorderSide(
                     color: Theme.of(context).primaryColor,
-                    width: 3,
+                    width: Sizes.size3,
                   ),
-                  insets: const EdgeInsets.only(bottom: 44),
+                  insets:
+                      const EdgeInsets.only(bottom: Sizes.size44 + Sizes.size1),
                 ),
                 unselectedLabelColor: Colors.black,
               ),

--- a/lib/screens/chats/chat_list_screen.dart
+++ b/lib/screens/chats/chat_list_screen.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:honbap_signal_flutter/models/chats/chat_list_model.dart';
+import 'package:honbap_signal_flutter/screens/chats/widgets/chats_chatcard_widget.dart';
 import 'package:honbap_signal_flutter/tools/push_new_screen.dart';
-import 'package:honbap_signal_flutter/widgets/chats_screen/chats_chatcard_widget.dart';
 
 class ChatListScreen extends StatefulWidget {
   const ChatListScreen({super.key});
@@ -55,7 +55,7 @@ class _ChatListScreenState extends State<ChatListScreen> {
         ],
       ),
       body: Container(
-        color: Colors.grey[200],
+        color: Colors.grey.shade200,
         child: FutureBuilder(
           future: _getChatList(),
           builder: (context, snapshot) {

--- a/lib/screens/chats/chat_room_screen.dart
+++ b/lib/screens/chats/chat_room_screen.dart
@@ -2,8 +2,10 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:honbap_signal_flutter/constants/gaps.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
 import 'package:honbap_signal_flutter/models/chats/chat_room_model.dart';
-import 'package:honbap_signal_flutter/widgets/chats_screen/chats_chatbox_widget.dart';
+import 'package:honbap_signal_flutter/screens/chats/widgets/chats_chatbox_widget.dart';
 
 class ChatRoomScreen extends StatefulWidget {
   final String nickname, profileImage;
@@ -97,7 +99,7 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> {
                       child: CustomScrollView(
                         slivers: [
                           const SliverToBoxAdapter(
-                            child: SizedBox(height: 10),
+                            child: Gaps.v10,
                           ),
                           for (var index = 0; index < chat.length; index++)
                             ChatBox(
@@ -107,7 +109,7 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> {
                               isSended: chat[index].nickname != widget.nickname,
                             ),
                           const SliverToBoxAdapter(
-                            child: SizedBox(height: 10),
+                            child: Gaps.v10,
                           ),
                         ],
                       ),
@@ -120,15 +122,20 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> {
               ),
             ),
             Container(
-              height: 50,
-              margin: const EdgeInsets.fromLTRB(10, 0, 10, 25),
+              height: Sizes.size48,
+              margin: const EdgeInsets.fromLTRB(
+                Sizes.size10,
+                0,
+                Sizes.size10,
+                Sizes.size24,
+              ),
               decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(25),
+                borderRadius: BorderRadius.circular(Sizes.size24),
                 boxShadow: [
                   BoxShadow(
-                    blurRadius: 5,
-                    spreadRadius: 1,
-                    color: Colors.grey[400]!,
+                    blurRadius: Sizes.size5,
+                    spreadRadius: Sizes.size1,
+                    color: Colors.grey.shade400,
                   ),
                 ],
                 color: Colors.white,
@@ -145,13 +152,14 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> {
                     ),
                   ),
                   Container(
-                    width: 1,
-                    height: 30,
-                    color: Colors.grey[300],
+                    width: Sizes.size1,
+                    height: Sizes.size28,
+                    color: Colors.grey.shade300,
                   ),
                   Expanded(
                     child: Container(
-                      margin: const EdgeInsets.symmetric(horizontal: 10),
+                      margin:
+                          const EdgeInsets.symmetric(horizontal: Sizes.size10),
                       child: const Text('input'),
                     ),
                   ),

--- a/lib/screens/chats/widgets/chats_chatbox_widget.dart
+++ b/lib/screens/chats/widgets/chats_chatbox_widget.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/gaps.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
 import 'package:honbap_signal_flutter/models/chats/chat_room_model.dart';
 import 'package:honbap_signal_flutter/tools/datetime_formatter.dart';
 
@@ -20,7 +22,7 @@ class ChatBox extends StatelessWidget {
   Widget build(BuildContext context) {
     return SliverToBoxAdapter(
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 10),
+        padding: const EdgeInsets.symmetric(horizontal: Sizes.size10),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -29,7 +31,7 @@ class ChatBox extends StatelessWidget {
                 : (index == 0 ||
                         chat[index].nickname != chat[index - 1].nickname)
                     ? Container(
-                        margin: const EdgeInsets.only(right: 10),
+                        margin: const EdgeInsets.only(right: Sizes.size10),
                         clipBehavior: Clip.hardEdge,
                         decoration: const BoxDecoration(
                           shape: BoxShape.circle,
@@ -37,13 +39,13 @@ class ChatBox extends StatelessWidget {
                         // Image.network로 변경하면 됨
                         child: Image.asset(
                           "assets/test/$profileImage.jpg",
-                          width: 50,
-                          height: 50,
+                          width: Sizes.size48 + Sizes.size2,
+                          height: Sizes.size48 + Sizes.size2,
                           fit: BoxFit.fill,
                         ),
                       )
                     : Container(
-                        width: 50,
+                        width: Sizes.size48 + Sizes.size2,
                       ),
             Flexible(
               child: Column(
@@ -56,12 +58,13 @@ class ChatBox extends StatelessWidget {
                       : (index == 0 ||
                               chat[index].nickname != chat[index - 1].nickname)
                           ? Container(
-                              margin: const EdgeInsets.only(bottom: 3),
+                              margin:
+                                  const EdgeInsets.only(bottom: Sizes.size3),
                               child: Text(
                                 chat[index].nickname,
                                 style: const TextStyle(
                                   fontWeight: FontWeight.w400,
-                                  fontSize: 12,
+                                  fontSize: Sizes.size12,
                                   color: Colors.black,
                                 ),
                               ),
@@ -80,20 +83,20 @@ class ChatBox extends StatelessWidget {
                                   chat[index].nickname !=
                                       chat[index + 1].nickname)
                           ? Container(
-                              margin: const EdgeInsets.only(right: 5),
+                              margin: const EdgeInsets.only(right: Sizes.size5),
                               child: Text(
                                 diffDatetime(chat[index].sendedAt),
                                 style: TextStyle(
                                   fontWeight: FontWeight.w400,
-                                  fontSize: 10,
-                                  color: Colors.grey[600],
+                                  fontSize: Sizes.size10,
+                                  color: Colors.grey.shade600,
                                 ),
                               ),
                             )
                           : Container(),
                       Flexible(
                         child: Container(
-                          padding: const EdgeInsets.all(7),
+                          padding: const EdgeInsets.all(Sizes.size7),
                           margin: EdgeInsets.only(
                               left: isSended
                                   ? 0
@@ -101,18 +104,18 @@ class ChatBox extends StatelessWidget {
                                           chat[index].nickname !=
                                               chat[index - 1].nickname)
                                       ? 0
-                                      : 10),
+                                      : Sizes.size10),
                           decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(10),
+                            borderRadius: BorderRadius.circular(Sizes.size10),
                             color: isSended
                                 ? Theme.of(context).primaryColor
-                                : Colors.grey[300],
+                                : Colors.grey.shade300,
                           ),
                           child: Text(
                             chat[index].message,
                             style: TextStyle(
                               fontWeight: FontWeight.w400,
-                              fontSize: 14,
+                              fontSize: Sizes.size14,
                               color: isSended ? Colors.white : Colors.black,
                             ),
                           ),
@@ -126,22 +129,21 @@ class ChatBox extends StatelessWidget {
                                   chat[index].nickname !=
                                       chat[index + 1].nickname)
                               ? Container(
-                                  margin: const EdgeInsets.only(left: 5),
+                                  margin:
+                                      const EdgeInsets.only(left: Sizes.size5),
                                   child: Text(
                                     diffDatetime(chat[index].sendedAt),
                                     style: TextStyle(
                                       fontWeight: FontWeight.w400,
-                                      fontSize: 10,
-                                      color: Colors.grey[600],
+                                      fontSize: Sizes.size10,
+                                      color: Colors.grey.shade600,
                                     ),
                                   ),
                                 )
                               : Container(),
                     ],
                   ),
-                  const SizedBox(
-                    height: 10,
-                  ),
+                  Gaps.v10,
                 ],
               ),
             ),

--- a/lib/screens/chats/widgets/chats_chatbox_widget.dart
+++ b/lib/screens/chats/widgets/chats_chatbox_widget.dart
@@ -26,74 +26,75 @@ class ChatBox extends StatelessWidget {
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            isSended
-                ? Container()
-                : (index == 0 ||
-                        chat[index].nickname != chat[index - 1].nickname)
-                    ? Container(
-                        margin: const EdgeInsets.only(right: Sizes.size10),
-                        clipBehavior: Clip.hardEdge,
-                        decoration: const BoxDecoration(
-                          shape: BoxShape.circle,
-                        ),
-                        // Image.network로 변경하면 됨
-                        child: Image.asset(
-                          "assets/test/$profileImage.jpg",
-                          width: Sizes.size48 + Sizes.size2,
-                          height: Sizes.size48 + Sizes.size2,
-                          fit: BoxFit.fill,
-                        ),
-                      )
-                    : Container(
-                        width: Sizes.size48 + Sizes.size2,
-                      ),
+            if (isSended)
+              Container()
+            else if (index == 0 ||
+                chat[index].nickname != chat[index - 1].nickname)
+              Container(
+                margin: const EdgeInsets.only(right: Sizes.size10),
+                clipBehavior: Clip.hardEdge,
+                decoration: const BoxDecoration(
+                  shape: BoxShape.circle,
+                ),
+                // Image.network로 변경하면 됨
+                child: Image.asset(
+                  "assets/test/$profileImage.jpg",
+                  width: Sizes.size48 + Sizes.size2,
+                  height: Sizes.size48 + Sizes.size2,
+                  fit: BoxFit.fill,
+                ),
+              )
+            else
+              Container(
+                width: Sizes.size48 + Sizes.size2,
+              ),
             Flexible(
               child: Column(
                 crossAxisAlignment: isSended
                     ? CrossAxisAlignment.end
                     : CrossAxisAlignment.start,
                 children: [
-                  isSended
-                      ? Container()
-                      : (index == 0 ||
-                              chat[index].nickname != chat[index - 1].nickname)
-                          ? Container(
-                              margin:
-                                  const EdgeInsets.only(bottom: Sizes.size3),
-                              child: Text(
-                                chat[index].nickname,
-                                style: const TextStyle(
-                                  fontWeight: FontWeight.w400,
-                                  fontSize: Sizes.size12,
-                                  color: Colors.black,
-                                ),
-                              ),
-                            )
-                          : Container(),
+                  if (isSended)
+                    Container()
+                  else if (index == 0 ||
+                      chat[index].nickname != chat[index - 1].nickname)
+                    Container(
+                      margin: const EdgeInsets.only(bottom: Sizes.size3),
+                      child: Text(
+                        chat[index].nickname,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w400,
+                          fontSize: Sizes.size12,
+                          color: Colors.black,
+                        ),
+                      ),
+                    )
+                  else
+                    Container(),
                   Row(
                     mainAxisAlignment: isSended
                         ? MainAxisAlignment.end
                         : MainAxisAlignment.start,
                     crossAxisAlignment: CrossAxisAlignment.end,
                     children: [
-                      isSended &&
-                              (index == chat.length - 1 ||
-                                  diffDatetime(chat[index].sendedAt) !=
-                                      diffDatetime(chat[index + 1].sendedAt) ||
-                                  chat[index].nickname !=
-                                      chat[index + 1].nickname)
-                          ? Container(
-                              margin: const EdgeInsets.only(right: Sizes.size5),
-                              child: Text(
-                                diffDatetime(chat[index].sendedAt),
-                                style: TextStyle(
-                                  fontWeight: FontWeight.w400,
-                                  fontSize: Sizes.size10,
-                                  color: Colors.grey.shade600,
-                                ),
-                              ),
-                            )
-                          : Container(),
+                      if (isSended &&
+                          (index == chat.length - 1 ||
+                              diffDatetime(chat[index].sendedAt) !=
+                                  diffDatetime(chat[index + 1].sendedAt) ||
+                              chat[index].nickname != chat[index + 1].nickname))
+                        Container(
+                          margin: const EdgeInsets.only(right: Sizes.size5),
+                          child: Text(
+                            diffDatetime(chat[index].sendedAt),
+                            style: TextStyle(
+                              fontWeight: FontWeight.w400,
+                              fontSize: Sizes.size10,
+                              color: Colors.grey.shade600,
+                            ),
+                          ),
+                        )
+                      else
+                        Container(),
                       Flexible(
                         child: Container(
                           padding: const EdgeInsets.all(Sizes.size7),
@@ -121,26 +122,25 @@ class ChatBox extends StatelessWidget {
                           ),
                         ),
                       ),
-                      isSended
-                          ? Container()
-                          : (index == chat.length - 1 ||
-                                  diffDatetime(chat[index].sendedAt) !=
-                                      diffDatetime(chat[index + 1].sendedAt) ||
-                                  chat[index].nickname !=
-                                      chat[index + 1].nickname)
-                              ? Container(
-                                  margin:
-                                      const EdgeInsets.only(left: Sizes.size5),
-                                  child: Text(
-                                    diffDatetime(chat[index].sendedAt),
-                                    style: TextStyle(
-                                      fontWeight: FontWeight.w400,
-                                      fontSize: Sizes.size10,
-                                      color: Colors.grey.shade600,
-                                    ),
-                                  ),
-                                )
-                              : Container(),
+                      if (isSended)
+                        Container()
+                      else if (index == chat.length - 1 ||
+                          diffDatetime(chat[index].sendedAt) !=
+                              diffDatetime(chat[index + 1].sendedAt) ||
+                          chat[index].nickname != chat[index + 1].nickname)
+                        Container(
+                          margin: const EdgeInsets.only(left: Sizes.size5),
+                          child: Text(
+                            diffDatetime(chat[index].sendedAt),
+                            style: TextStyle(
+                              fontWeight: FontWeight.w400,
+                              fontSize: Sizes.size10,
+                              color: Colors.grey.shade600,
+                            ),
+                          ),
+                        )
+                      else
+                        Container(),
                     ],
                   ),
                   Gaps.v10,

--- a/lib/screens/chats/widgets/chats_chatcard_widget.dart
+++ b/lib/screens/chats/widgets/chats_chatcard_widget.dart
@@ -78,27 +78,27 @@ class ChatCard extends StatelessWidget {
                             ),
                           ),
                         ),
-                        chat.unreadMessages != 0
-                            ? Container(
-                                width: Sizes.size16,
-                                height: Sizes.size16,
-                                margin:
-                                    const EdgeInsets.only(left: Sizes.size10),
-                                alignment: Alignment.center,
-                                decoration: BoxDecoration(
-                                  shape: BoxShape.circle,
-                                  color: Theme.of(context).primaryColor,
-                                ),
-                                child: Text(
-                                  '${chat.unreadMessages}',
-                                  style: const TextStyle(
-                                    fontWeight: FontWeight.w400,
-                                    fontSize: Sizes.size10,
-                                    color: Colors.white,
-                                  ),
-                                ),
-                              )
-                            : Container(),
+                        if (chat.unreadMessages != 0)
+                          Container(
+                            width: Sizes.size16,
+                            height: Sizes.size16,
+                            margin: const EdgeInsets.only(left: Sizes.size10),
+                            alignment: Alignment.center,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Theme.of(context).primaryColor,
+                            ),
+                            child: Text(
+                              '${chat.unreadMessages}',
+                              style: const TextStyle(
+                                fontWeight: FontWeight.w400,
+                                fontSize: Sizes.size10,
+                                color: Colors.white,
+                              ),
+                            ),
+                          )
+                        else
+                          Container(),
                       ],
                     ),
                   ],

--- a/lib/screens/chats/widgets/chats_chatcard_widget.dart
+++ b/lib/screens/chats/widgets/chats_chatcard_widget.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/gaps.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
 import 'package:honbap_signal_flutter/models/chats/chat_list_model.dart';
 import 'package:honbap_signal_flutter/tools/datetime_formatter.dart';
 
@@ -15,15 +17,15 @@ class ChatCard extends StatelessWidget {
     return Column(
       children: [
         Container(
-          height: 70,
+          height: Sizes.size72,
           color: Colors.white,
-          padding: const EdgeInsets.only(right: 10),
+          padding: const EdgeInsets.only(right: Sizes.size10),
           child: Row(
             children: [
               Container(
-                width: 50,
-                height: 50,
-                margin: const EdgeInsets.symmetric(horizontal: 10),
+                width: Sizes.size48,
+                height: Sizes.size48,
+                margin: const EdgeInsets.symmetric(horizontal: Sizes.size10),
                 clipBehavior: Clip.hardEdge,
                 decoration: const BoxDecoration(
                   shape: BoxShape.circle,
@@ -37,9 +39,7 @@ class ChatCard extends StatelessWidget {
               Flexible(
                 child: Column(
                   children: [
-                    const SizedBox(
-                      height: 8,
-                    ),
+                    Gaps.v8,
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       crossAxisAlignment: CrossAxisAlignment.center,
@@ -48,7 +48,7 @@ class ChatCard extends StatelessWidget {
                           chat.nickname,
                           style: const TextStyle(
                             fontWeight: FontWeight.w700,
-                            fontSize: 14,
+                            fontSize: Sizes.size14,
                             color: Colors.black,
                           ),
                         ),
@@ -56,15 +56,13 @@ class ChatCard extends StatelessWidget {
                           diffDatetime(chat.laseSendedAt),
                           style: TextStyle(
                             fontWeight: FontWeight.w400,
-                            fontSize: 10,
-                            color: Colors.grey[600],
+                            fontSize: Sizes.size10,
+                            color: Colors.grey.shade600,
                           ),
                         ),
                       ],
                     ),
-                    const SizedBox(
-                      height: 7,
-                    ),
+                    Gaps.v7,
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
@@ -75,16 +73,17 @@ class ChatCard extends StatelessWidget {
                             overflow: TextOverflow.ellipsis,
                             style: TextStyle(
                               fontWeight: FontWeight.w400,
-                              fontSize: 12,
-                              color: Colors.grey[600],
+                              fontSize: Sizes.size12,
+                              color: Colors.grey.shade600,
                             ),
                           ),
                         ),
                         chat.unreadMessages != 0
                             ? Container(
-                                width: 15,
-                                height: 15,
-                                margin: const EdgeInsets.only(left: 10),
+                                width: Sizes.size16,
+                                height: Sizes.size16,
+                                margin:
+                                    const EdgeInsets.only(left: Sizes.size10),
                                 alignment: Alignment.center,
                                 decoration: BoxDecoration(
                                   shape: BoxShape.circle,
@@ -94,7 +93,7 @@ class ChatCard extends StatelessWidget {
                                   '${chat.unreadMessages}',
                                   style: const TextStyle(
                                     fontWeight: FontWeight.w400,
-                                    fontSize: 10,
+                                    fontSize: Sizes.size10,
                                     color: Colors.white,
                                   ),
                                 ),
@@ -109,8 +108,8 @@ class ChatCard extends StatelessWidget {
           ),
         ),
         Container(
-          height: 1.5,
-          color: Colors.grey[200],
+          height: Sizes.size3 / Sizes.size2,
+          color: Colors.grey.shade200,
         ),
       ],
     );

--- a/lib/screens/login/login_phone_auth_screen.dart
+++ b/lib/screens/login/login_phone_auth_screen.dart
@@ -84,44 +84,43 @@ class _LoginPhoneAuthScreenState extends State<LoginPhoneAuthScreen> {
                         ],
                       ),
                     ),
-                    isPhoneSubmit
-                        ? Form(
-                            key: _authNumFormKey,
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  '문자 메세지로 도착한',
-                                  style:
-                                      Theme.of(context).textTheme.titleMedium,
-                                ),
-                                Text(
-                                  '인증번호를 입력해 주세요',
-                                  style:
-                                      Theme.of(context).textTheme.titleMedium,
-                                ),
-                                Gaps.v10,
-                                TextFormField(
-                                  focusNode: _authNumNode,
-                                  keyboardType: TextInputType.number,
-                                  onTap: () {
-                                    _authNumNode.requestFocus();
-                                  },
-                                  validator: (value) {
-                                    if (value == null || value.isEmpty) {
-                                      return "인증번호를 입력해주세요";
-                                    }
-                                    authNum = value;
-                                    return null;
-                                  },
-                                  onFieldSubmitted: (value) {
-                                    submitHandler();
-                                  },
-                                ),
-                              ],
+                    if (isPhoneSubmit)
+                      Form(
+                        key: _authNumFormKey,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              '문자 메세지로 도착한',
+                              style: Theme.of(context).textTheme.titleMedium,
                             ),
-                          )
-                        : Container(),
+                            Text(
+                              '인증번호를 입력해 주세요',
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            Gaps.v10,
+                            TextFormField(
+                              focusNode: _authNumNode,
+                              keyboardType: TextInputType.number,
+                              onTap: () {
+                                _authNumNode.requestFocus();
+                              },
+                              validator: (value) {
+                                if (value == null || value.isEmpty) {
+                                  return "인증번호를 입력해주세요";
+                                }
+                                authNum = value;
+                                return null;
+                              },
+                              onFieldSubmitted: (value) {
+                                submitHandler();
+                              },
+                            ),
+                          ],
+                        ),
+                      )
+                    else
+                      Container(),
                   ],
                 ),
               ),

--- a/lib/screens/login/login_phone_auth_screen.dart
+++ b/lib/screens/login/login_phone_auth_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:honbap_signal_flutter/constants/gaps.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
 import 'package:honbap_signal_flutter/tools/phone_format_updater.dart';
-import 'package:honbap_signal_flutter/widgets/login_screen/login_button_widget.dart';
+import 'package:honbap_signal_flutter/screens/login/widgets/login_button_widget.dart';
 
 class LoginPhoneAuthScreen extends StatefulWidget {
   const LoginPhoneAuthScreen({super.key});
@@ -36,7 +38,7 @@ class _LoginPhoneAuthScreenState extends State<LoginPhoneAuthScreen> {
           children: [
             Flexible(
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
+                padding: const EdgeInsets.symmetric(horizontal: Sizes.size20),
                 child: Column(
                   children: [
                     Form(
@@ -52,9 +54,7 @@ class _LoginPhoneAuthScreenState extends State<LoginPhoneAuthScreen> {
                             '입력해 주시는 번호로 인증 번호가 발송됩니다',
                             style: Theme.of(context).textTheme.labelSmall,
                           ),
-                          const SizedBox(
-                            height: 20,
-                          ),
+                          Gaps.v20,
                           TextFormField(
                             focusNode: _phoneNumFocusNode,
                             keyboardType: TextInputType.number,
@@ -80,9 +80,7 @@ class _LoginPhoneAuthScreenState extends State<LoginPhoneAuthScreen> {
                               submitHandler();
                             },
                           ),
-                          const SizedBox(
-                            height: 60,
-                          ),
+                          Gaps.v60,
                         ],
                       ),
                     ),
@@ -102,9 +100,7 @@ class _LoginPhoneAuthScreenState extends State<LoginPhoneAuthScreen> {
                                   style:
                                       Theme.of(context).textTheme.titleMedium,
                                 ),
-                                const SizedBox(
-                                  height: 10,
-                                ),
+                                Gaps.v10,
                                 TextFormField(
                                   focusNode: _authNumNode,
                                   keyboardType: TextInputType.number,

--- a/lib/screens/login/login_screen.dart
+++ b/lib/screens/login/login_screen.dart
@@ -1,8 +1,10 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/gaps.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
 import 'package:honbap_signal_flutter/models/kakao_login_model.dart';
-import 'package:honbap_signal_flutter/widgets/login_screen/login_button_widget.dart';
+import 'package:honbap_signal_flutter/screens/login/widgets/login_button_widget.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:http/http.dart' as http;
 
@@ -13,14 +15,14 @@ class LoginScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(20),
+        preferredSize: const Size.fromHeight(Sizes.size20),
         child: AppBar(
           elevation: 0,
           backgroundColor: Colors.transparent,
         ),
       ),
       body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 20),
+        padding: const EdgeInsets.symmetric(horizontal: Sizes.size20),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -44,18 +46,14 @@ class LoginScreen extends StatelessWidget {
                       child: Text('이미지'),
                     ),
                   ),
-                  const SizedBox(
-                    height: 10,
-                  ),
+                  Gaps.v10,
                   LoginBtnWidget(
                     title: "회원가입 하기",
                     bgColor: Theme.of(context).primaryColor,
                     borderColor: Theme.of(context).primaryColor,
                     textColor: Colors.white,
                   ),
-                  const SizedBox(
-                    height: 10,
-                  ),
+                  Gaps.v10,
                   LoginBtnWidget(
                     title: "로그인 하기",
                     bgColor: Colors.white,
@@ -73,31 +71,29 @@ class LoginScreen extends StatelessWidget {
                     children: [
                       Flexible(
                         child: Container(
-                          height: 2,
+                          height: Sizes.size2,
                           color: const Color(0xffe6e6e6),
                         ),
                       ),
                       const Padding(
-                        padding: EdgeInsets.symmetric(horizontal: 15),
+                        padding: EdgeInsets.symmetric(horizontal: Sizes.size14),
                         child: Text(
                           '간편로그인',
                           style: TextStyle(
                             color: Color(0xFFB8B8B8),
-                            fontSize: 14,
+                            fontSize: Sizes.size14,
                           ),
                         ),
                       ),
                       Flexible(
                         child: Container(
-                          height: 2,
+                          height: Sizes.size2,
                           color: const Color(0xffe6e6e6),
                         ),
                       ),
                     ],
                   ),
-                  const SizedBox(
-                    height: 20,
-                  ),
+                  Gaps.v20,
                   GestureDetector(
                     onTap: () async {
                       try {
@@ -135,14 +131,12 @@ class LoginScreen extends StatelessWidget {
                       textColor: const Color(0xff402326),
                       icon: Image.asset(
                         'assets/images/kakaotalk_logo.png',
-                        width: 23,
-                        height: 23,
+                        width: Sizes.size24,
+                        height: Sizes.size24,
                       ),
                     ),
                   ),
-                  const SizedBox(
-                    height: 10,
-                  ),
+                  Gaps.v10,
                   Text(
                     '회원가입 시 혼밥시그널의 서비스 이용 약관과 개인정보 보호정책에 동의하게 됩니다.',
                     style: Theme.of(context).textTheme.labelSmall,

--- a/lib/screens/login/widgets/login_button_widget.dart
+++ b/lib/screens/login/widgets/login_button_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
 
 class LoginBtnWidget extends StatelessWidget {
   const LoginBtnWidget({
@@ -19,13 +20,13 @@ class LoginBtnWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: 50,
+      height: Sizes.size52,
       decoration: BoxDecoration(
         color: bgColor,
         borderRadius: BorderRadius.circular(borderRad),
         border: Border.all(
           color: borderColor,
-          width: 1,
+          width: Sizes.size1,
         ),
       ),
       child: Center(
@@ -34,7 +35,7 @@ class LoginBtnWidget extends StatelessWidget {
           children: [
             icon != null
                 ? Padding(
-                    padding: const EdgeInsets.only(right: 5),
+                    padding: const EdgeInsets.only(right: Sizes.size5),
                     child: Container(
                       child: icon,
                     ),
@@ -44,7 +45,7 @@ class LoginBtnWidget extends StatelessWidget {
               title,
               style: TextStyle(
                 color: textColor,
-                fontSize: 14,
+                fontSize: Sizes.size14,
               ),
             ),
           ],

--- a/lib/screens/login/widgets/login_button_widget.dart
+++ b/lib/screens/login/widgets/login_button_widget.dart
@@ -33,14 +33,15 @@ class LoginBtnWidget extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            icon != null
-                ? Padding(
-                    padding: const EdgeInsets.only(right: Sizes.size5),
-                    child: Container(
-                      child: icon,
-                    ),
-                  )
-                : Container(),
+            if (icon != null)
+              Padding(
+                padding: const EdgeInsets.only(right: Sizes.size5),
+                child: Container(
+                  child: icon,
+                ),
+              )
+            else
+              Container(),
             Text(
               title,
               style: TextStyle(

--- a/lib/screens/signal/signal_list_screen.dart
+++ b/lib/screens/signal/signal_list_screen.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/gaps.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+import 'package:honbap_signal_flutter/screens/signal/widgets/signal_filtertag_widget.dart';
+import 'package:honbap_signal_flutter/screens/signal/widgets/signal_usercard_widget.dart';
+
+class SignalListScreen extends StatefulWidget {
+  const SignalListScreen({super.key});
+
+  @override
+  State<SignalListScreen> createState() => _SignalListScreenState();
+}
+
+class _SignalListScreenState extends State<SignalListScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          '내 근처 시그널',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        elevation: 0,
+        centerTitle: false,
+        backgroundColor: Colors.white,
+      ),
+      body: Column(
+        children: [
+          Gaps.v10,
+          Row(
+            children: [
+              Expanded(
+                child: ShaderMask(
+                  shaderCallback: (Rect rect) {
+                    return const LinearGradient(
+                      begin: Alignment.centerLeft,
+                      end: Alignment.centerRight,
+                      colors: [
+                        Colors.purple,
+                        Colors.transparent,
+                        Colors.transparent,
+                        Colors.purple
+                      ],
+                      stops: [
+                        0.0,
+                        0.01,
+                        0.99,
+                        1.0
+                      ], // 10% purple, 80% transparent, 10% purple
+                    ).createShader(rect);
+                  },
+                  blendMode: BlendMode.dstOut,
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(
+                        Sizes.size14,
+                        Sizes.size5,
+                        0,
+                        Sizes.size5,
+                      ),
+                      child: Row(
+                        children: const [
+                          FilterTag(tag: '인생선배'),
+                          FilterTag(tag: '푸드파이터'),
+                          FilterTag(tag: '이구역토박이'),
+                          FilterTag(tag: '김치ㅁㄴㅇㅁㄴㅇ'),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              IconButton(
+                onPressed: () {},
+                icon: const Icon(Icons.filter_alt_sharp),
+              ),
+              Gaps.h4,
+            ],
+          ),
+          Expanded(
+            child: CustomScrollView(
+              slivers: [
+                SliverPadding(
+                  padding: const EdgeInsets.all(Sizes.size16),
+                  sliver: SliverGrid(
+                    gridDelegate:
+                        const SliverGridDelegateWithMaxCrossAxisExtent(
+                      maxCrossAxisExtent: Sizes.size96 * 3,
+                      mainAxisSpacing: Sizes.size20,
+                      crossAxisSpacing: Sizes.size20,
+                      childAspectRatio: 4 / 5,
+                    ),
+                    delegate: SliverChildBuilderDelegate(
+                      (context, index) {
+                        return GestureDetector(
+                          onTap: () {
+                            print('tap $index');
+                          },
+                          child: const SignalUserCard(),
+                        );
+                      },
+                      childCount: 10,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/signal/signal_list_screen.dart
+++ b/lib/screens/signal/signal_list_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:honbap_signal_flutter/constants/gaps.dart';
 import 'package:honbap_signal_flutter/constants/sizes.dart';
+import 'package:honbap_signal_flutter/screens/signal/signal_userprofile_dialog.dart';
 import 'package:honbap_signal_flutter/screens/signal/widgets/signal_filtertag_widget.dart';
 import 'package:honbap_signal_flutter/screens/signal/widgets/signal_usercard_widget.dart';
 
@@ -95,7 +96,13 @@ class _SignalListScreenState extends State<SignalListScreen> {
                       (context, index) {
                         return GestureDetector(
                           onTap: () {
-                            print('tap $index');
+                            showDialog(
+                              context: context,
+                              barrierDismissible: false,
+                              builder: (context) {
+                                return const SignalUserDialog();
+                              },
+                            );
                           },
                           child: const SignalUserCard(),
                         );

--- a/lib/screens/signal/signal_userprofile_dialog.dart
+++ b/lib/screens/signal/signal_userprofile_dialog.dart
@@ -1,0 +1,329 @@
+import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/gaps.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+import 'package:honbap_signal_flutter/screens/signal/widgets/signal_dialog_usertag_widget%20copy.dart';
+
+class SignalUserDialog extends StatefulWidget {
+  const SignalUserDialog({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<SignalUserDialog> createState() => _SignalUserDialogState();
+}
+
+class _SignalUserDialogState extends State<SignalUserDialog> {
+  final ScrollController _scrollController = ScrollController();
+  bool isTop = true;
+  bool isOrange = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(() {
+      setState(() {
+        if (_scrollController.offset == 0) {
+          isTop = true;
+        } else {
+          isTop = false;
+        }
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _scrollController.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(
+          Radius.circular(Sizes.size10),
+        ),
+      ),
+      contentPadding: const EdgeInsets.all(0),
+      contentTextStyle: TextStyle(
+        fontSize: Sizes.size12,
+        fontWeight: FontWeight.w400,
+        color: Colors.grey.shade700,
+      ),
+      clipBehavior: Clip.hardEdge,
+      content: SizedBox(
+        width: MediaQuery.of(context).size.width - Sizes.size20,
+        height: Sizes.size96 * 5,
+        child: Stack(
+          alignment: AlignmentDirectional.topCenter,
+          children: [
+            Column(
+              children: [
+                Expanded(
+                  child: ShaderMask(
+                    shaderCallback: (Rect rect) {
+                      return const LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          Colors.transparent,
+                          Colors.transparent,
+                          Colors.purple,
+                        ],
+                        stops: [
+                          0.0,
+                          0.95,
+                          0.98,
+                        ], // 10% purple, 80% transparent, 10% purple
+                      ).createShader(rect);
+                    },
+                    blendMode: BlendMode.dstOut,
+                    child: SingleChildScrollView(
+                      controller: _scrollController,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: Sizes.size20),
+                        child: Column(
+                          children: [
+                            Gaps.v32,
+                            Container(
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                border: Border.all(
+                                  width: Sizes.size4,
+                                  color: Theme.of(context).primaryColor,
+                                ),
+                              ),
+                              child: Container(
+                                clipBehavior: Clip.hardEdge,
+                                decoration: const BoxDecoration(
+                                  shape: BoxShape.circle,
+                                ),
+                                // Image.network로 변경하면 됨
+                                child: Image.asset(
+                                  "assets/test/test_image.jpg",
+                                  width: Sizes.size64 * 2,
+                                  height: Sizes.size64 * 2,
+                                  fit: BoxFit.fill,
+                                ),
+                              ),
+                            ),
+                            Gaps.v16,
+                            const Text(
+                              "웅인데웅",
+                              style: TextStyle(
+                                fontSize: Sizes.size14,
+                                fontWeight: FontWeight.w600,
+                                color: Colors.black,
+                              ),
+                            ),
+                            Gaps.v16,
+                            const Text(
+                              '혼밥마스터 이지만 오늘은 누군가 대화하며 밥을 먹고 싶습니다! 한식, 중식, 일식 좋아합니다.',
+                              textAlign: TextAlign.center,
+                            ),
+                            if (isOrange)
+                              Container(
+                                margin:
+                                    const EdgeInsets.only(top: Sizes.size32),
+                                padding: const EdgeInsets.all(Sizes.size12),
+                                decoration: BoxDecoration(
+                                  border: Border.all(
+                                    width: Sizes.size1,
+                                    color: Theme.of(context).primaryColor,
+                                  ),
+                                  borderRadius:
+                                      BorderRadius.circular(Sizes.size7),
+                                ),
+                                child: Column(
+                                  children: const [
+                                    InfoRow(
+                                      title: '만남위치',
+                                      icon: Icons.location_on_outlined,
+                                      info: '공덕역 2번출구',
+                                    ),
+                                    InfoRow(
+                                      title: '약속시간',
+                                      icon: Icons.access_time_rounded,
+                                      info: '19:00',
+                                    ),
+                                    InfoRow(
+                                      title: '메뉴',
+                                      icon: Icons.restaurant_menu_rounded,
+                                      info: '스시, 해산물',
+                                    ),
+                                  ],
+                                ),
+                              )
+                            else
+                              Container(),
+                            Gaps.v32,
+                            SizedBox(
+                              width: double.infinity,
+                              child: Wrap(
+                                direction: Axis.horizontal,
+                                spacing: Sizes.size4,
+                                runSpacing: Sizes.size4,
+                                children: const <Widget>[
+                                  DialogUserTag(tag: '양꼬치'),
+                                  DialogUserTag(tag: '삼각지역'),
+                                  DialogUserTag(tag: '반주사랑'),
+                                  DialogUserTag(tag: '이구역토박이'),
+                                  DialogUserTag(tag: '한식'),
+                                ],
+                              ),
+                            ),
+                            Gaps.v32,
+                            SizedBox(
+                              width: double.infinity,
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: const [
+                                  Text('불호음식: 땅콩, 회, 복숭아'),
+                                  Gaps.v3,
+                                  Text('선호음식: 국물류'),
+                                  Gaps.v3,
+                                  Text('선호장소: 2호선, 7호선, 강남근처'),
+                                  Gaps.v3,
+                                  Text('MBTI: ISFJ'),
+                                ],
+                              ),
+                            ),
+                            Gaps.v20,
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Expanded(
+                      child: GestureDetector(
+                        onTap: () {
+                          print('clicked dismiss');
+                        },
+                        child: Container(
+                          alignment: Alignment.center,
+                          height: Sizes.size52,
+                          color: Colors.grey.shade300,
+                          child: const Text(
+                            '요청 거절하기',
+                            style: TextStyle(
+                              color: Colors.black,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: GestureDetector(
+                        onTap: () {
+                          print('clicked accept');
+                        },
+                        child: Container(
+                          alignment: Alignment.center,
+                          height: Sizes.size52,
+                          color: Theme.of(context).primaryColor,
+                          child: const Text(
+                            '요청 수락하기',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                )
+              ],
+            ),
+            if (isTop)
+              IgnorePointer(
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: Sizes.size52),
+                  child: Align(
+                    alignment: Alignment.bottomCenter,
+                    child: Icon(
+                      Icons.keyboard_arrow_down_rounded,
+                      size: Sizes.size40,
+                      color: Colors.grey.shade500,
+                    ),
+                  ),
+                ),
+              )
+            else
+              Container(),
+            Align(
+              alignment: Alignment.topRight,
+              child: IconButton(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+                icon: Icon(
+                  Icons.close,
+                  color: Colors.grey.shade700,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class InfoRow extends StatelessWidget {
+  final String title, info;
+  final IconData icon;
+
+  const InfoRow({
+    Key? key,
+    required this.title,
+    required this.info,
+    required this.icon,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Container(
+          width: Sizes.size60,
+          height: Sizes.size24,
+          alignment: Alignment.centerLeft,
+          decoration: const BoxDecoration(),
+          clipBehavior: Clip.hardEdge,
+          child: Text(
+            '$title ',
+            style: TextStyle(
+              fontSize: Sizes.size14,
+              color: Theme.of(context).primaryColor,
+            ),
+          ),
+        ),
+        Gaps.h3,
+        Icon(
+          icon,
+          size: Sizes.size20,
+          color: Colors.grey.shade600,
+        ),
+        Gaps.h7,
+        Expanded(
+          child: Text(
+            ' $info',
+            style: TextStyle(
+              fontSize: Sizes.size14,
+              color: Colors.grey.shade600,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/signal/widgets/signal_card_usertag_widget.dart
+++ b/lib/screens/signal/widgets/signal_card_usertag_widget.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:honbap_signal_flutter/constants/sizes.dart';
 
-class UserTag extends StatelessWidget {
+class CardUserTag extends StatelessWidget {
   final String tag;
 
-  const UserTag({
+  const CardUserTag({
     Key? key,
     required this.tag,
   }) : super(key: key);

--- a/lib/screens/signal/widgets/signal_dialog_usertag_widget copy.dart
+++ b/lib/screens/signal/widgets/signal_dialog_usertag_widget copy.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+
+class DialogUserTag extends StatelessWidget {
+  final String tag;
+
+  const DialogUserTag({
+    Key? key,
+    required this.tag,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        vertical: Sizes.size7,
+        horizontal: Sizes.size10,
+      ),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(Sizes.size20),
+        color: Colors.white,
+        border: Border.all(
+          width: Sizes.size3 / Sizes.size2,
+          color: Colors.grey.shade300,
+        ),
+      ),
+      child: Text(
+        tag,
+        style: const TextStyle(
+          color: Colors.black,
+          fontSize: Sizes.size12,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/signal/widgets/signal_filtertag_widget.dart
+++ b/lib/screens/signal/widgets/signal_filtertag_widget.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+
+class FilterTag extends StatelessWidget {
+  final String tag;
+
+  const FilterTag({
+    Key? key,
+    required this.tag,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(right: Sizes.size10),
+      padding: const EdgeInsets.all(Sizes.size10),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(Sizes.size20),
+        color: Colors.grey.shade200,
+      ),
+      child: Text(tag),
+    );
+  }
+}

--- a/lib/screens/signal/widgets/signal_usercard_widget.dart
+++ b/lib/screens/signal/widgets/signal_usercard_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:honbap_signal_flutter/constants/gaps.dart';
 import 'package:honbap_signal_flutter/constants/sizes.dart';
-import 'package:honbap_signal_flutter/screens/signal/widgets/signal_usertag_widget.dart';
+import 'package:honbap_signal_flutter/screens/signal/widgets/signal_card_usertag_widget.dart';
 
 class SignalUserCard extends StatelessWidget {
   const SignalUserCard({
@@ -85,11 +85,11 @@ class SignalUserCard extends StatelessWidget {
                     spacing: Sizes.size4,
                     runSpacing: Sizes.size4,
                     children: const <Widget>[
-                      UserTag(tag: '양꼬치'),
-                      UserTag(tag: '삼각지역'),
-                      UserTag(tag: '반주사랑'),
-                      UserTag(tag: '이구역토박이'),
-                      UserTag(tag: '한식'),
+                      CardUserTag(tag: '양꼬치'),
+                      CardUserTag(tag: '삼각지역'),
+                      CardUserTag(tag: '반주사랑'),
+                      CardUserTag(tag: '이구역토박이'),
+                      CardUserTag(tag: '한식'),
                     ],
                   ),
                 ),

--- a/lib/screens/signal/widgets/signal_usercard_widget.dart
+++ b/lib/screens/signal/widgets/signal_usercard_widget.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/gaps.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+import 'package:honbap_signal_flutter/screens/signal/widgets/signal_usertag_widget.dart';
+
+class SignalUserCard extends StatelessWidget {
+  const SignalUserCard({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(Sizes.size16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.shade300,
+            blurRadius: Sizes.size5,
+            spreadRadius: Sizes.size2,
+          ),
+        ],
+      ),
+      child: ShaderMask(
+        shaderCallback: (Rect rect) {
+          return const LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              Colors.transparent,
+              Colors.transparent,
+              Colors.purple,
+            ],
+            stops: [
+              0.0,
+              0.90,
+              0.99,
+            ], // 10% purple, 80% transparent, 10% purple
+          ).createShader(rect);
+        },
+        blendMode: BlendMode.dstOut,
+        child: SingleChildScrollView(
+          physics: const NeverScrollableScrollPhysics(),
+          child: Column(
+            children: [
+              Gaps.v20,
+              Container(
+                clipBehavior: Clip.hardEdge,
+                decoration: const BoxDecoration(
+                  shape: BoxShape.circle,
+                ),
+                // Image.network로 변경하면 됨
+                child: Image.asset(
+                  "assets/test/test_image.jpg",
+                  width: Sizes.size80,
+                  height: Sizes.size80,
+                  fit: BoxFit.fill,
+                ),
+              ),
+              Gaps.v7,
+              const Text(
+                '웅인데웅',
+                style: TextStyle(
+                  fontSize: Sizes.size14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              Gaps.v3,
+              Text(
+                '나와 400m   19분 전',
+                style: TextStyle(
+                  color: Colors.grey.shade600,
+                  fontSize: Sizes.size9,
+                ),
+              ),
+              Gaps.v5,
+              Padding(
+                padding: const EdgeInsets.all(Sizes.size7),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: Wrap(
+                    direction: Axis.horizontal,
+                    spacing: Sizes.size4,
+                    runSpacing: Sizes.size4,
+                    children: const <Widget>[
+                      UserTag(tag: '양꼬치'),
+                      UserTag(tag: '삼각지역'),
+                      UserTag(tag: '반주사랑'),
+                      UserTag(tag: '이구역토박이'),
+                      UserTag(tag: '한식'),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/signal/widgets/signal_usertag_widget.dart
+++ b/lib/screens/signal/widgets/signal_usertag_widget.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+
+class UserTag extends StatelessWidget {
+  final String tag;
+
+  const UserTag({
+    Key? key,
+    required this.tag,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        vertical: Sizes.size7,
+        horizontal: Sizes.size10,
+      ),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(Sizes.size20),
+        color: Colors.grey.shade200,
+      ),
+      child: Text(
+        tag,
+        style: const TextStyle(
+          fontSize: Sizes.size10,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- [implement signal page](https://github.com/MadMax-Team/honbap_signal_flutter/commit/12851821955eac55a23cdabb4935038114c8ea62)
내 근처 시그널 페이지 디자인 구현 완료했습니다.
동시에 `size`, `Sizedbox`와 관련된 모든 정수 리터럴을 `constants` 폴더 안에 상수화 시켰습니다.
또한, `widgets` 폴더를 각 `screen` 안에 별도로 관리할 수 있도록 경로를 수정했습니다.

- [implement signal userprofile dialog](https://github.com/MadMax-Team/honbap_signal_flutter/commit/9de79b1aca50ac7e71148f7b26abfed6a58dd59b)
내 근처 시그널 > 유저 클릭시 다이얼로그 화면을 디자인 구현 완료했습니다.
또한, `? :` 문법을 `if else` 문법으로 변환하였습니다.