### PR TITLE
fcm test passed

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,9 +47,8 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
-        <meta-data
+        <!-- <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
-            android:value="high_importance_channel" />
-
+            android:value="high_importance_channel" /> -->
     </application>
 </manifest>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -9,7 +8,6 @@ import 'package:honbap_signal_flutter/bloc/auth/authentication/authentication_st
 import 'package:honbap_signal_flutter/bloc/home/signal_box_dialog/signal_box_dialog_bloc.dart';
 import 'package:honbap_signal_flutter/bloc/signal/signal_list_bloc.dart';
 import 'package:honbap_signal_flutter/constants/sizes.dart';
-import 'package:honbap_signal_flutter/cubit/fcm_cubit.dart';
 import 'package:honbap_signal_flutter/cubit/user_cubit.dart';
 import 'package:honbap_signal_flutter/cubit/user_profile_upload_cubit.dart';
 import 'package:honbap_signal_flutter/repository/honbab/home/home_repository.dart';
@@ -21,7 +19,6 @@ import 'package:honbap_signal_flutter/screens/common/user_profile_setting/user_p
 import 'package:honbap_signal_flutter/screens/routes/route_navigation_widget.dart';
 import 'package:honbap_signal_flutter/screens/auth/auth_screen.dart';
 import 'package:honbap_signal_flutter/screens/splash/splash_page.dart';
-
 import 'bloc/chat/chat_list/chat_list_bloc.dart';
 import 'bloc/home/get_signal_apply/home_signal_apply_bloc.dart';
 
@@ -124,22 +121,6 @@ class _AppState extends State<App> {
         ),
       ],
     );
-
-    // fcm listening
-    // at foground
-    FirebaseMessaging.onMessage.listen((RemoteMessage? message) {
-      context.read<FCMCubit>().listenFCM(message);
-    });
-    // at background
-    FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage? message) {
-      context.read<FCMCubit>().listenFCM(message);
-    });
-    // at terminate
-    FirebaseMessaging.instance
-        .getInitialMessage()
-        .then((RemoteMessage? message) {
-      context.read<FCMCubit>().listenFCM(message);
-    });
   }
 
   @override

--- a/lib/cubit/fcm_cubit.dart
+++ b/lib/cubit/fcm_cubit.dart
@@ -8,7 +8,15 @@ class FCMCubit extends Cubit<FCMState> {
   FCMCubit(
     this._fcmToken,
     RemoteMessage? bgMessage,
-  ) : super(FCMState.fromBgMessage(bgMessage));
+  ) : super(FCMState.fromBgMessage(bgMessage)) {
+    // fcm listening
+    // at foground
+    FirebaseMessaging.onMessage.listen(listenFCM);
+    // at background
+    FirebaseMessaging.onMessageOpenedApp.listen(listenFCM);
+    // at terminate
+    FirebaseMessaging.instance.getInitialMessage().then(listenFCM);
+  }
 
   // token getter
   String get token => _fcmToken;
@@ -17,6 +25,7 @@ class FCMCubit extends Cubit<FCMState> {
   void listenFCM(RemoteMessage? message) {
     if (message != null) {
       if (message.notification != null) {
+        print('fg fcm: ${message.notification?.title}');
         emit(FCMState(
           state: FCMEvent.message,
           body: message.notification!.body,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,6 +41,7 @@ void main() async {
 
 Future<void> _onBackgroundMessage(RemoteMessage message) async {
   bgMessage = message;
+  print('bg fcm: ${message.notification?.title}');
 }
 
 Future<void> initializeDependencies() async {
@@ -100,7 +101,11 @@ class MyApp extends StatelessWidget {
             create: (context) => SplashBloc(),
           ),
           BlocProvider(
-            create: (context) => FCMCubit(fcmToken, bgMessage),
+            create: (context) => FCMCubit(
+              fcmToken,
+              bgMessage,
+            ),
+            lazy: false,
           ),
         ],
         child: const App(),

--- a/lib/screens/auth/auth_screen.dart
+++ b/lib/screens/auth/auth_screen.dart
@@ -9,6 +9,7 @@ import 'package:honbap_signal_flutter/bloc/auth/post_user_signin/post_user_signi
 import 'package:honbap_signal_flutter/bloc/auth/post_user_signup/post_user_signup_bloc.dart';
 import 'package:honbap_signal_flutter/constants/gaps.dart';
 import 'package:honbap_signal_flutter/constants/sizes.dart';
+import 'package:honbap_signal_flutter/cubit/fcm_cubit.dart';
 import 'package:honbap_signal_flutter/models/kakao_login_model.dart';
 import 'package:honbap_signal_flutter/repository/honbab/auth/auth_repository.dart';
 import 'package:honbap_signal_flutter/repository/honbab/auth/auth_signup_repository.dart';
@@ -112,108 +113,120 @@ class AuthScreen extends StatelessWidget {
         ),
       ),
       resizeToAvoidBottomInset: false,
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: Sizes.size20),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              "함께 밥 먹을 친구를",
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-            Text(
-              "찾아볼까요?",
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-            Flexible(
-              flex: 3,
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Container(
-                    color: Colors.grey.shade400,
-                    height: 150,
-                    child: const Center(
-                      child: Text('이미지'),
-                    ),
-                  ),
-                  Gaps.v10,
-                  GestureDetector(
-                    onTap: () => _onSignUpTap(context),
-                    child: AuthLoginButton(
-                      title: "회원가입 하기",
-                      bgColor: Theme.of(context).primaryColor,
-                      borderColor: Theme.of(context).primaryColor,
-                      textColor: Colors.white,
-                    ),
-                  ),
-                  Gaps.v10,
-                  GestureDetector(
-                    onTap: () => _onSignInTap(context),
-                    child: AuthLoginButton(
-                      title: "로그인 하기",
-                      bgColor: Colors.white,
-                      borderColor: Theme.of(context).primaryColor,
-                      textColor: Theme.of(context).primaryColor,
-                    ),
-                  ),
-                ],
+      body: BlocListener<FCMCubit, FCMState>(
+        listener: (context, state) {
+          if (state.state == FCMEvent.message) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.body ?? 'na'),
               ),
-            ),
-            Flexible(
-              flex: 2,
-              child: Column(
-                children: [
-                  Row(
-                    children: [
-                      Flexible(
-                        child: Container(
-                          height: Sizes.size2,
-                          color: const Color(0xffe6e6e6),
-                        ),
+            );
+          }
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: Sizes.size20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                "함께 밥 먹을 친구를",
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              Text(
+                "찾아볼까요?",
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              Flexible(
+                flex: 3,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Container(
+                      color: Colors.grey.shade400,
+                      height: 150,
+                      child: const Center(
+                        child: Text('이미지'),
                       ),
-                      const Padding(
-                        padding: EdgeInsets.symmetric(horizontal: Sizes.size14),
-                        child: Text(
-                          '간편로그인',
-                          style: TextStyle(
-                            color: Color(0xFFB8B8B8),
-                            fontSize: Sizes.size14,
+                    ),
+                    Gaps.v10,
+                    GestureDetector(
+                      onTap: () => _onSignUpTap(context),
+                      child: AuthLoginButton(
+                        title: "회원가입 하기",
+                        bgColor: Theme.of(context).primaryColor,
+                        borderColor: Theme.of(context).primaryColor,
+                        textColor: Colors.white,
+                      ),
+                    ),
+                    Gaps.v10,
+                    GestureDetector(
+                      onTap: () => _onSignInTap(context),
+                      child: AuthLoginButton(
+                        title: "로그인 하기",
+                        bgColor: Colors.white,
+                        borderColor: Theme.of(context).primaryColor,
+                        textColor: Theme.of(context).primaryColor,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Flexible(
+                flex: 2,
+                child: Column(
+                  children: [
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Container(
+                            height: Sizes.size2,
+                            color: const Color(0xffe6e6e6),
                           ),
                         ),
-                      ),
-                      Flexible(
-                        child: Container(
-                          height: Sizes.size2,
-                          color: const Color(0xffe6e6e6),
+                        const Padding(
+                          padding:
+                              EdgeInsets.symmetric(horizontal: Sizes.size14),
+                          child: Text(
+                            '간편로그인',
+                            style: TextStyle(
+                              color: Color(0xFFB8B8B8),
+                              fontSize: Sizes.size14,
+                            ),
+                          ),
+                        ),
+                        Flexible(
+                          child: Container(
+                            height: Sizes.size2,
+                            color: const Color(0xffe6e6e6),
+                          ),
+                        ),
+                      ],
+                    ),
+                    Gaps.v20,
+                    GestureDetector(
+                      onTap: () => _authWithKakao(context),
+                      child: AuthLoginButton(
+                        title: "카카오로 로그인",
+                        bgColor: const Color(0xffffe500),
+                        borderColor: const Color(0xffffe500),
+                        textColor: const Color(0xff402326),
+                        icon: Image.asset(
+                          'assets/images/kakaotalk_logo.png',
+                          width: Sizes.size24,
+                          height: Sizes.size24,
                         ),
                       ),
-                    ],
-                  ),
-                  Gaps.v20,
-                  GestureDetector(
-                    onTap: () => _authWithKakao(context),
-                    child: AuthLoginButton(
-                      title: "카카오로 로그인",
-                      bgColor: const Color(0xffffe500),
-                      borderColor: const Color(0xffffe500),
-                      textColor: const Color(0xff402326),
-                      icon: Image.asset(
-                        'assets/images/kakaotalk_logo.png',
-                        width: Sizes.size24,
-                        height: Sizes.size24,
-                      ),
                     ),
-                  ),
-                  Gaps.v10,
-                  Text(
-                    '회원가입 시 혼밥시그널의 서비스 이용 약관과 개인정보 보호정책에 동의하게 됩니다.',
-                    style: Theme.of(context).textTheme.labelSmall,
-                  )
-                ],
+                    Gaps.v10,
+                    Text(
+                      '회원가입 시 혼밥시그널의 서비스 이용 약관과 개인정보 보호정책에 동의하게 됩니다.',
+                      style: Theme.of(context).textTheme.labelSmall,
+                    )
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## fcm fo/background 수신, 및 테스트 수행 중 발생한 문제점
- 테스트 코드가 없었음
- bg에서 푸쉬알림 클릭시 앱 실행이 안됨
- foground 수신 코드를 cubit 외부에서 관리함

## 수정완료 사항
- 테스트 코드 구현완료
  이제, 앱 실행 중 fcm이 오면 snackbar로 해당 메세지 body를 확인할 수 있습니다.

- bg에서 푸쉬알림 클릭시 앱 실행
  정확한 원인이 무엇인지 파악되진 않았습니다만, 아래의 두 가지 중 하나가 원인이라 짐작됩니다.
  
  1. `android/app/src/main/AndroidManifest.xml`의 `meta-data: default_notification_channel_id`의 value
  2. fcm `message.data.click_action` or `message.android.notification.click_action` 의 유무
  
  따라서 위 두 케이스 모두 없애고 진행한 결과 정상동작 하였습니다..

- foground 수신 코드를 cubit 내부에서 관리
  이제 이벤트 핸들러를 큐빗 생성 시점에 생성자 body에서 호출하는 식으로 수정했습니다.