### PR TITLE
10/5 Update

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -142,27 +142,32 @@ class _AppState extends State<App> {
         scaffoldBackgroundColor: Colors.white,
         primarySwatch: createMaterialColor(const Color(0xffff4b25)),
         fontFamily: 'Pretendard',
-        textTheme: const TextTheme(
+        textTheme: TextTheme(
           // 2022 sets
           // displayLarge, displayMedium, displaySmall
           // headlineLarge, headlineMedium, headlineSmall
           // titleLarge, titleMedium, titleSmall
           // bodyLarge, bodyMedium, bodySmall
           // labelLarge, labelMedium, labelSmall
-          titleMedium: TextStyle(
+          titleMedium: const TextStyle(
             fontWeight: FontWeight.w700,
             fontSize: Sizes.size20,
           ),
-          titleSmall: TextStyle(
+          titleSmall: const TextStyle(
             fontWeight: FontWeight.w700,
             fontSize: Sizes.size16,
           ),
-          headlineMedium: TextStyle(
+          headlineMedium: const TextStyle(
             fontWeight: FontWeight.w500,
             color: Colors.black,
             fontSize: Sizes.size18,
           ),
-          labelSmall: TextStyle(
+          labelMedium: TextStyle(
+            color: Colors.grey.shade700,
+            fontSize: Sizes.size14,
+            letterSpacing: Sizes.size1 / Sizes.size2,
+          ),
+          labelSmall: const TextStyle(
             color: Color(0xFFB8B8B8),
             fontSize: Sizes.size14,
             letterSpacing: Sizes.size1 / Sizes.size2,

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -165,7 +165,6 @@ class _AppState extends State<App> {
           labelMedium: TextStyle(
             color: Colors.grey.shade700,
             fontSize: Sizes.size14,
-            letterSpacing: Sizes.size1 / Sizes.size2,
           ),
           labelSmall: const TextStyle(
             color: Color(0xFFB8B8B8),

--- a/lib/cubit/user_pw_change_cubit.dart
+++ b/lib/cubit/user_pw_change_cubit.dart
@@ -1,0 +1,75 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:honbap_signal_flutter/models/user/user_model.dart';
+import 'package:honbap_signal_flutter/repository/honbab/user/user_profile_repository.dart';
+
+class UserPWChangeCubit extends Cubit<UserPWChangeState> {
+  final UserProfileRepository userProfileRepository;
+  final UserModel userModel;
+
+  UserPWChangeCubit({
+    required this.userProfileRepository,
+    required this.userModel,
+  }) : super(const UserPWChangeState());
+
+  void changeOldPW(String? value) {
+    emit(state.copyWith(oldPassword: value));
+  }
+
+  void changeNewPW(String? value) {
+    emit(state.copyWith(newPassword: value));
+  }
+
+  void updatePassword() async {
+    emit(state.copyWith(status: UserPWChangeStatus.updating));
+
+    final res = await userProfileRepository.updatePassword(
+      jwt: userModel.jwt ?? '',
+      pw: state.newPassword!,
+    );
+
+    if (res != null && res.code == 1000) {
+      emit(state.copyWith(status: UserPWChangeStatus.success));
+    } else {
+      emit(state.copyWith(status: UserPWChangeStatus.failed));
+    }
+    emit(state.copyWith(status: UserPWChangeStatus.init));
+  }
+}
+
+enum UserPWChangeStatus {
+  init,
+  updating,
+  success,
+  failed,
+}
+
+class UserPWChangeState extends Equatable {
+  final UserPWChangeStatus status;
+  final String? oldPassword;
+  final String? newPassword;
+
+  const UserPWChangeState({
+    this.status = UserPWChangeStatus.init,
+    this.oldPassword,
+    this.newPassword,
+  });
+
+  UserPWChangeState copyWith({
+    UserPWChangeStatus? status,
+    String? oldPassword,
+    String? newPassword,
+  }) =>
+      UserPWChangeState(
+        status: status ?? this.status,
+        oldPassword: oldPassword ?? this.oldPassword,
+        newPassword: newPassword ?? this.newPassword,
+      );
+
+  @override
+  List<Object?> get props => [
+        status,
+        oldPassword,
+        newPassword,
+      ];
+}

--- a/lib/repository/honbab/user/user_profile_repository.dart
+++ b/lib/repository/honbab/user/user_profile_repository.dart
@@ -70,4 +70,26 @@ class UserProfileRepository {
       return null;
     }
   }
+
+  Future<ResCodeModel?> updatePassword({
+    required String jwt,
+    required String pw,
+  }) async {
+    final Map<String, String> headers = {
+      "Content-Type": "application/json",
+      'x-access-token': jwt,
+    };
+
+    final res = await http.patch(
+      Uri.parse('${ApiEndpoint.honbab}/user/myinfo/modifypw'),
+      headers: headers,
+      body: jsonEncode({'password': pw}),
+    );
+
+    if (res.statusCode == 200) {
+      return ResCodeModel.fromJson(jsonDecode(res.body));
+    } else {
+      return null;
+    }
+  }
 }

--- a/lib/screens/mypage/mypage_screen.dart
+++ b/lib/screens/mypage/mypage_screen.dart
@@ -135,9 +135,13 @@ class MyPageScreen extends StatelessWidget {
                             ),
                           ),
                           Gaps.v7,
-                          const MyPageRoundButton(
-                            isTransparent: true,
-                            text: '계정관리',
+                          GestureDetector(
+                            onTap: () =>
+                                PushNewScreen.openUserAccount(context: context),
+                            child: const MyPageRoundButton(
+                              isTransparent: true,
+                              text: '계정관리',
+                            ),
                           ),
                         ],
                       ),

--- a/lib/screens/mypage/user_account_setting/user_account_setting_screen.dart
+++ b/lib/screens/mypage/user_account_setting/user_account_setting_screen.dart
@@ -4,6 +4,7 @@ import 'package:honbap_signal_flutter/constants/gaps.dart';
 import 'package:honbap_signal_flutter/cubit/user_cubit.dart';
 import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/widgets/user_account_setting_button.dart';
 import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/widgets/user_account_setting_section.dart';
+import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/widgets/user_logout_dialog.dart';
 
 class UserAccountSettingScreen extends StatelessWidget {
   const UserAccountSettingScreen({super.key});
@@ -49,7 +50,13 @@ class UserAccountSettingScreen extends StatelessWidget {
               UserAccountSettingButton(
                 title: '로그아웃',
                 onTap: () {
-                  print('onclick');
+                  showDialog(
+                    context: context,
+                    barrierDismissible: false,
+                    builder: (context) {
+                      return const UserLogoutDialog();
+                    },
+                  );
                 },
               ),
             ],

--- a/lib/screens/mypage/user_account_setting/user_account_setting_screen.dart
+++ b/lib/screens/mypage/user_account_setting/user_account_setting_screen.dart
@@ -5,6 +5,7 @@ import 'package:honbap_signal_flutter/cubit/user_cubit.dart';
 import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/widgets/user_account_setting_button.dart';
 import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/widgets/user_account_setting_section.dart';
 import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/widgets/user_logout_dialog.dart';
+import 'package:honbap_signal_flutter/tools/push_new_screen.dart';
 
 class UserAccountSettingScreen extends StatelessWidget {
   const UserAccountSettingScreen({super.key});
@@ -68,15 +69,12 @@ class UserAccountSettingScreen extends StatelessWidget {
             children: [
               UserAccountSettingButton(
                 title: '비밀번호 변경',
-                onTap: () {
-                  print('onclick');
-                },
+                onTap: () =>
+                    PushNewScreen.openUserPasswordChange(context: context),
               ),
               UserAccountSettingButton(
                 title: '회원탈퇴',
-                onTap: () {
-                  print('onclick');
-                },
+                onTap: () {},
               ),
             ],
           ),

--- a/lib/screens/mypage/user_account_setting/user_account_setting_screen.dart
+++ b/lib/screens/mypage/user_account_setting/user_account_setting_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:honbap_signal_flutter/constants/gaps.dart';
+import 'package:honbap_signal_flutter/cubit/user_cubit.dart';
+import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/widgets/user_account_setting_button.dart';
+import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/widgets/user_account_setting_section.dart';
+
+class UserAccountSettingScreen extends StatelessWidget {
+  const UserAccountSettingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          '계정설정',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        elevation: 0,
+        centerTitle: false,
+        foregroundColor: Colors.black,
+        backgroundColor: Colors.white,
+      ),
+      body: ListView(
+        children: [
+          UserAccountSettingSection(
+            title: '계정관리',
+            text: '서비스에서 사용하는 내 계정 정보를 관리할 수 있습니다.',
+            children: [
+              UserAccountSettingButton(
+                title: '이메일',
+                value: context.read<UserCubit>().state.user?.email ?? '',
+              ),
+              UserAccountSettingButton(
+                title: '이름',
+                value: context.read<UserCubit>().state.user?.userName ?? '',
+              ),
+              UserAccountSettingButton(
+                title: '휴대폰 번호',
+                value: context
+                        .read<UserCubit>()
+                        .state
+                        .user
+                        ?.phoneNum
+                        ?.replaceAllMapped(RegExp(r'(\d{3})(\d{3,4})(\d{4})'),
+                            (m) => '${m[1]}-${m[2]}-${m[3]}') ??
+                    '',
+              ),
+              UserAccountSettingButton(
+                title: '로그아웃',
+                onTap: () {
+                  print('onclick');
+                },
+              ),
+            ],
+          ),
+          Gaps.v40,
+          UserAccountSettingSection(
+            title: '개인 정보 보호',
+            text: '내 계정을 안전하게 보호하기 위한 정보를 관리할 수 있습니다.',
+            children: [
+              UserAccountSettingButton(
+                title: '비밀번호 변경',
+                onTap: () {
+                  print('onclick');
+                },
+              ),
+              UserAccountSettingButton(
+                title: '회원탈퇴',
+                onTap: () {
+                  print('onclick');
+                },
+              ),
+            ],
+          ),
+          Gaps.v32,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/mypage/user_account_setting/user_password_change/user_password_change_screen.dart
+++ b/lib/screens/mypage/user_account_setting/user_password_change/user_password_change_screen.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:honbap_signal_flutter/constants/gaps.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+import 'package:honbap_signal_flutter/cubit/user_pw_change_cubit.dart';
+import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/user_password_change/widgets/user_password_submit_button.dart';
+import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/user_password_change/widgets/user_password_textform.dart';
+
+class UserPasswordChangeScreen extends StatefulWidget {
+  const UserPasswordChangeScreen({super.key});
+
+  @override
+  State<UserPasswordChangeScreen> createState() =>
+      _UserPasswordChangeScreenState();
+}
+
+class _UserPasswordChangeScreenState extends State<UserPasswordChangeScreen> {
+  final FocusNode _oldPwFocusNode = FocusNode();
+  final FocusNode _newPw1FocusNode = FocusNode();
+  final FocusNode _newPw2FocusNode = FocusNode();
+  String? _newPassword = '';
+
+  String? _newPw1validator(String? value) {
+    String pattern =
+        r'^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,16}$';
+    RegExp regExp = RegExp(pattern);
+
+    // Invaled
+    if (value != null && !regExp.hasMatch(value)) {
+      return '8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.';
+    }
+
+    // Valid
+    return null;
+  }
+
+  String? _newPw2validator(String? value) {
+    if (_newPw1validator(value) != null) {
+      return '8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.';
+    }
+    // Invaled
+    if (_newPassword != value) {
+      return '비밀번호가 일치하지 않습니다.';
+    }
+
+    // Valid
+    return null;
+  }
+
+  void _onOldPwSubmit(String value) {
+    context.read<UserPWChangeCubit>().changeOldPW(value);
+  }
+
+  void _onNewPw1Submit(String value) {
+    _newPassword = value;
+  }
+
+  void _onNewPw2Submit(String value) {
+    context.read<UserPWChangeCubit>().changeNewPW(value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: FocusScope.of(context).unfocus,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(
+            '비밀번호 변경',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          elevation: 0,
+          centerTitle: false,
+          foregroundColor: Colors.black,
+          backgroundColor: Colors.white,
+        ),
+        body: BlocListener<UserPWChangeCubit, UserPWChangeState>(
+          listener: (context, state) {
+            if (state.status == UserPWChangeStatus.success) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: const Text('비밀번호를 변경했습니다!'),
+                  elevation: 0,
+                  backgroundColor: Theme.of(context).primaryColor,
+                ),
+              );
+            }
+
+            if (state.status == UserPWChangeStatus.failed) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: const Text('비밀번호 변경에 실패했습니다'),
+                  elevation: 0,
+                  backgroundColor: Theme.of(context).primaryColor,
+                ),
+              );
+            }
+          },
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: Sizes.size20),
+            child: ListView(
+              children: [
+                Gaps.v20,
+                Text(
+                  '현재 비밀번호',
+                  style: Theme.of(context).textTheme.labelMedium,
+                ),
+                UserPasswordTextForm(
+                  hint: '비밀번호를 입력해주세요.',
+                  focusNode: _oldPwFocusNode,
+                  onChange: (_) {},
+                  validator: (_) => null,
+                  onSubmit: _onOldPwSubmit,
+                ),
+                Gaps.v20,
+                Text(
+                  '새 비밀번호',
+                  style: Theme.of(context).textTheme.labelMedium,
+                ),
+                UserPasswordTextForm(
+                  hint: '새 비밀번호를 입력해주세요.',
+                  focusNode: _newPw1FocusNode,
+                  onChange: _onNewPw1Submit,
+                  validator: _newPw1validator,
+                  checkValidOnChange: true,
+                  onSubmit: _onNewPw1Submit,
+                ),
+                UserPasswordTextForm(
+                  isLast: true,
+                  hint: '새 비밀번호를 확인해주세요.',
+                  focusNode: _newPw2FocusNode,
+                  onChange: (_) {},
+                  validator: _newPw2validator,
+                  checkValidOnChange: true,
+                  onSubmit: _onNewPw2Submit,
+                ),
+                Text(
+                  '영문 대소문자, 숫자, 특수문자를 3가지 이상으로 조합하여 8자 이상 16자 이하로 입력해주세요.',
+                  style: TextStyle(
+                    color: Colors.grey.shade700,
+                    fontSize: Sizes.size12,
+                  ),
+                ),
+                Gaps.v20,
+                const UserPasswordSubmitButton(),
+                Gaps.v32,
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/mypage/user_account_setting/user_password_change/widgets/user_password_submit_button.dart
+++ b/lib/screens/mypage/user_account_setting/user_password_change/widgets/user_password_submit_button.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+import 'package:honbap_signal_flutter/cubit/user_pw_change_cubit.dart';
+
+class UserPasswordSubmitButton extends StatelessWidget {
+  const UserPasswordSubmitButton({super.key});
+
+  void _onTap(BuildContext context) {
+    final cubit = context.read<UserPWChangeCubit>();
+
+    if (cubit.state.newPassword?.isNotEmpty == true) {
+      if (cubit.state.status == UserPWChangeStatus.updating) return;
+
+      cubit.updatePassword();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<UserPWChangeCubit, UserPWChangeState>(
+      builder: (context, state) => GestureDetector(
+        onTap: () => _onTap(context),
+        child: Container(
+          height: Sizes.size48,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(Sizes.size5),
+            color: state.newPassword?.isNotEmpty == true
+                ? Theme.of(context).primaryColor
+                : Colors.grey.shade400,
+          ),
+          child: Center(
+            child: state.status == UserPWChangeStatus.updating
+                ? const CircularProgressIndicator(
+                    color: Colors.white,
+                  )
+                : const Text(
+                    '저장',
+                    style: TextStyle(
+                      color: Colors.white,
+                    ),
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/mypage/user_account_setting/user_password_change/widgets/user_password_textform.dart
+++ b/lib/screens/mypage/user_account_setting/user_password_change/widgets/user_password_textform.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+
+class UserPasswordTextForm extends StatefulWidget {
+  final bool isLast;
+  final String? hint;
+  final FocusNode focusNode;
+  final Function(String) onChange;
+  final String? Function(String?) validator;
+  final bool checkValidOnChange;
+  final Function(String) onSubmit;
+
+  const UserPasswordTextForm({
+    super.key,
+    this.isLast = false,
+    this.hint,
+    required this.focusNode,
+    required this.onChange,
+    required this.validator,
+    this.checkValidOnChange = false,
+    required this.onSubmit,
+  });
+
+  @override
+  State<UserPasswordTextForm> createState() => _UserPasswordTextFormState();
+}
+
+class _UserPasswordTextFormState extends State<UserPasswordTextForm> {
+  String _currValue = '';
+  bool _obscureText = true;
+  bool _isChanged = false;
+  final _key = GlobalKey<FormFieldState<String>>();
+
+  void _toggleObscureText() {
+    setState(() {
+      _obscureText = !_obscureText;
+    });
+  }
+
+  void _onChange(String value) {
+    _isChanged = true;
+    _currValue = value;
+    widget.onChange(value);
+
+    if (widget.checkValidOnChange) {
+      _key.currentState?.validate();
+    }
+  }
+
+  void _checkValidate({
+    bool nextFocus = false,
+  }) {
+    if (!_isChanged) return;
+
+    // check validate
+    _key.currentState?.validate();
+    if (widget.validator(_currValue) != null) return;
+
+    // submit value
+    widget.onSubmit(_currValue);
+
+    // change focus
+    if (nextFocus) {
+      FocusScope.of(context).nextFocus();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: Sizes.size80,
+      child: TextFormField(
+        key: _key,
+        focusNode: widget.focusNode,
+        autocorrect: false,
+        enableSuggestions: false,
+        obscureText: _obscureText,
+        textInputAction:
+            widget.isLast ? TextInputAction.done : TextInputAction.next,
+        style: const TextStyle(fontSize: Sizes.size16),
+        decoration: InputDecoration(
+          hintText: widget.hint,
+          hintStyle: Theme.of(context).textTheme.labelMedium,
+          suffixIcon: GestureDetector(
+            onTap: _toggleObscureText,
+            child: Container(
+              width: Sizes.size28,
+              height: Sizes.size28,
+              alignment: Alignment.center,
+              child: FaIcon(
+                _obscureText ? FontAwesomeIcons.eye : FontAwesomeIcons.eyeSlash,
+                color: Colors.grey.shade300,
+                size: Sizes.size20,
+              ),
+            ),
+          ),
+          enabledBorder: UnderlineInputBorder(
+            borderSide: BorderSide(
+              color: Colors.grey.shade400,
+            ),
+          ),
+          focusedBorder: UnderlineInputBorder(
+            borderSide: BorderSide(
+              color: Theme.of(context).primaryColor,
+            ),
+          ),
+        ),
+        cursorColor: Theme.of(context).primaryColor,
+        validator: (value) => widget.validator(value),
+        onChanged: _onChange,
+        onTap: () => _checkValidate(),
+        onEditingComplete: () => _checkValidate(),
+        onTapOutside: (_) => _checkValidate(),
+        onFieldSubmitted: (_) => _checkValidate(nextFocus: true),
+      ),
+    );
+  }
+}

--- a/lib/screens/mypage/user_account_setting/widgets/user_account_setting_button.dart
+++ b/lib/screens/mypage/user_account_setting/widgets/user_account_setting_button.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+
+class UserAccountSettingButton extends StatelessWidget {
+  final String title;
+  final String? value;
+  final Function()? onTap;
+
+  const UserAccountSettingButton({
+    super.key,
+    required this.title,
+    this.value,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.translucent,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: Sizes.size16),
+        child: Row(
+          children: [
+            Expanded(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(title),
+                  if (value != null)
+                    Text(
+                      value!,
+                      style: TextStyle(color: Colors.grey.shade700),
+                    ),
+                ],
+              ),
+            ),
+            if (onTap != null)
+              const Padding(
+                padding: EdgeInsets.only(left: Sizes.size16),
+                child: Icon(
+                  FontAwesomeIcons.chevronRight,
+                  size: Sizes.size12,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/mypage/user_account_setting/widgets/user_account_setting_section.dart
+++ b/lib/screens/mypage/user_account_setting/widgets/user_account_setting_section.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:honbap_signal_flutter/constants/gaps.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+
+class UserAccountSettingSection extends StatelessWidget {
+  final String title;
+  final String text;
+  final List<Widget> children;
+
+  const UserAccountSettingSection({
+    super.key,
+    required this.title,
+    required this.text,
+    required this.children,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.symmetric(
+          horizontal: BorderSide(
+            width: Sizes.size1,
+            color: Colors.grey.shade400,
+          ),
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.only(
+          top: Sizes.size32,
+          right: Sizes.size20,
+          left: Sizes.size20,
+          bottom: Sizes.size10,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            Gaps.v5,
+            Text(
+              text,
+              style: Theme.of(context).textTheme.labelSmall,
+            ),
+            Gaps.v20,
+            ListView.separated(
+              shrinkWrap: true,
+              itemBuilder: (context, index) => children[index],
+              separatorBuilder: (context, index) => Container(
+                height: Sizes.size1,
+                color: Colors.grey.shade300,
+              ),
+              itemCount: children.length,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/mypage/user_account_setting/widgets/user_account_setting_section.dart
+++ b/lib/screens/mypage/user_account_setting/widgets/user_account_setting_section.dart
@@ -47,6 +47,7 @@ class UserAccountSettingSection extends StatelessWidget {
             Gaps.v20,
             ListView.separated(
               shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
               itemBuilder: (context, index) => children[index],
               separatorBuilder: (context, index) => Container(
                 height: Sizes.size1,

--- a/lib/screens/mypage/user_account_setting/widgets/user_logout_dialog.dart
+++ b/lib/screens/mypage/user_account_setting/widgets/user_logout_dialog.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:honbap_signal_flutter/bloc/auth/authentication/authentication_bloc.dart';
+import 'package:honbap_signal_flutter/bloc/auth/authentication/authentication_event.dart';
+import 'package:honbap_signal_flutter/constants/gaps.dart';
+import 'package:honbap_signal_flutter/constants/sizes.dart';
+
+class UserLogoutDialog extends StatelessWidget {
+  const UserLogoutDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(
+          Radius.circular(Sizes.size7),
+        ),
+      ),
+      contentPadding: const EdgeInsets.all(0),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Gaps.v20,
+          Text(
+            '로그아웃',
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+          Gaps.v20,
+          Text(
+            '정말 로그아웃하시겠습니까?',
+            style: Theme.of(context).textTheme.labelMedium,
+          ),
+          Gaps.v12,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Expanded(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTap: Navigator.of(context).pop,
+                  child: Container(
+                    alignment: Alignment.center,
+                    height: Sizes.size44,
+                    child: Text(
+                      '취소',
+                      style: TextStyle(
+                        color: Colors.grey.shade400,
+                        fontSize: Sizes.size14,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Expanded(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTap: () {
+                    context
+                        .read<AuthenticationBloc>()
+                        .add(const AuthenticationLogout());
+                  },
+                  child: Container(
+                    alignment: Alignment.center,
+                    height: Sizes.size44,
+                    child: Text(
+                      '로그아웃',
+                      style: TextStyle(
+                        color: Theme.of(context).primaryColor,
+                        fontSize: Sizes.size14,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/tools/push_new_screen.dart
+++ b/lib/tools/push_new_screen.dart
@@ -3,11 +3,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:honbap_signal_flutter/bloc/chat/chat_room/chat_room_bloc.dart';
 import 'package:honbap_signal_flutter/cubit/user_cubit.dart';
 import 'package:honbap_signal_flutter/cubit/user_profile_upload_cubit.dart';
+import 'package:honbap_signal_flutter/cubit/user_pw_change_cubit.dart';
 import 'package:honbap_signal_flutter/repository/honbab/chat/chat_room_repository.dart';
 import 'package:honbap_signal_flutter/repository/honbab/user/user_profile_repository.dart';
 import 'package:honbap_signal_flutter/screens/chats/chat_room_screen.dart';
 import 'package:honbap_signal_flutter/screens/common/user_profile_setting/user_profile_setting_screen.dart';
 import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/user_account_setting_screen.dart';
+import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/user_password_change/user_password_change_screen.dart';
 
 class PushNewScreen {
   static Route _createRoute(Widget widget) {
@@ -81,6 +83,24 @@ class PushNewScreen {
     Navigator.push(
       context,
       _createRoute(const UserAccountSettingScreen()),
+    );
+  }
+
+  static void openUserPasswordChange({
+    required dynamic context,
+  }) {
+    Navigator.push(
+      context,
+      _createRoute(RepositoryProvider(
+        create: (context) => UserProfileRepository(),
+        child: BlocProvider(
+          create: (context) => UserPWChangeCubit(
+            userProfileRepository: context.read<UserProfileRepository>(),
+            userModel: context.read<UserCubit>().state.user!,
+          ),
+          child: const UserPasswordChangeScreen(),
+        ),
+      )),
     );
   }
 }

--- a/lib/tools/push_new_screen.dart
+++ b/lib/tools/push_new_screen.dart
@@ -7,6 +7,7 @@ import 'package:honbap_signal_flutter/repository/honbab/chat/chat_room_repositor
 import 'package:honbap_signal_flutter/repository/honbab/user/user_profile_repository.dart';
 import 'package:honbap_signal_flutter/screens/chats/chat_room_screen.dart';
 import 'package:honbap_signal_flutter/screens/common/user_profile_setting/user_profile_setting_screen.dart';
+import 'package:honbap_signal_flutter/screens/mypage/user_account_setting/user_account_setting_screen.dart';
 
 class PushNewScreen {
   static Route _createRoute(Widget widget) {
@@ -71,6 +72,15 @@ class PushNewScreen {
           ),
         ),
       ),
+    );
+  }
+
+  static void openUserAccount({
+    required dynamic context,
+  }) {
+    Navigator.push(
+      context,
+      _createRoute(const UserAccountSettingScreen()),
     );
   }
 }


### PR DESCRIPTION
## 10/5 업데이트 내역입니다.

### 계정설정 화면 구현완료
계정관리 화면 구현 완료했습니다.
그에 따라 로그아웃 기능 역시 이 화면에서도 가능하도록 구현했습니다.
따라서 홈 화면에 ... 으로 로그아웃 하는 테스트용 기능은 이제 필요 없으니 지워도 됩니다.

### 비밀번호 변경 구현완료
비밀변호 변경 화면 및 로직 구현 완료했습니다.
다만, 현재 api 스펙상 기존 비밀번호를 검사하는 로직이 없기에, 기존 비밀번호를 입력받는 form은 있으나 마나한 상태입니다.
나중에 기능 추가할 수 있도록 구현은 완료한 상태입니다.
이 외에는 새로운 비밀번호를 받으면 정상적으로 업데이트됨은 확인했습니다.